### PR TITLE
refactor: externalize events and improve timeline layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,33 @@
 # Epoch
+
 This is an idea at this early stage; an experiment. A website which shows a chronology of the events of the Baha'i Faith throughout history, connecting users to relevant guidance along this timeline.
 
 ## Project Status
-Likely this will be slow moving as an individual initiative, progressing when I have time. Eventually it may pick up steam. 
+
+Likely this will be slow moving as an individual initiative, progressing when I have time. Eventually it may pick up steam.
 
 **Update: September 2023**
 Right now it is in its earliest stage. I am prototyping different ways to reliably render an interactive timeline. The features which could be enabled by this scaffold include:
-- Dynamic zooming and scrolling through the timeline, likely with an overview widget somewhere on screen. 
-- Information hierarchy between different types of events. Cycle -> Dispensation -> Age and so on. 
+
+- Dynamic zooming and scrolling through the timeline, likely with an overview widget somewhere on screen.
+- Information hierarchy between different types of events. Cycle -> Dispensation -> Age and so on.
 - Linking rich resources including links to the official Reference Library for events. This will require some sort of expanded card interface, likely achived with CSS page transitions
 
-At this stage mobile is out of scope, but the CSS scaffold I'm building would allow for it. The main issue is information density, so on small viewports there will need to be a maximum number of years or zoom levels perhaps. Zoom levels in general will reauire some experimentation and thought. Certain things will need to be hidden. Likely depending on viewport size, a certain number of hierarchical levels down from the top item will be shown. One of the key navigational tools is likely going to be clicking on events to adjust them into the Zoom. It will then become the top level event visible, with some sort of mechanism  to click up a layer or all the way out intuitively. 
+At this stage mobile is out of scope, but the CSS scaffold I'm building would allow for it. The main issue is information density, so on small viewports there will need to be a maximum number of years or zoom levels perhaps. Zoom levels in general will reauire some experimentation and thought. Certain things will need to be hidden. Likely depending on viewport size, a certain number of hierarchical levels down from the top item will be shown. One of the key navigational tools is likely going to be clicking on events to adjust them into the Zoom. It will then become the top level event visible, with some sort of mechanism to click up a layer or all the way out intuitively.
 
 ## Principles
+
 This will be developed to run on a serverless architecture, using a jamstack methodology. The data will be hosted in a headless CMS and structured logically, with the build process ideally producing a statically generated website.
 
-A separate  process of data management and carw will be needed to maintain the integrity of the source database. Further consultation with others and potentially institutions of the Faith will be necessary at that stage to think about how best to gather and maintain that information. There is potential for a small group of authorized moderators who have access to the CMS, paired with a feedback mechanism which allows users of the website to request the additon of additional events through an inline form. 
+A separate process of data management and carw will be needed to maintain the integrity of the source database. Further consultation with others and potentially institutions of the Faith will be necessary at that stage to think about how best to gather and maintain that information. There is potential for a small group of authorized moderators who have access to the CMS, paired with a feedback mechanism which allows users of the website to request the additon of additional events through an inline form.
 
 This will use the gregorian calendar system for now. It would be nice to overlay the Bahá'í equivilant dates in the future, but this would need to be rendered from the gregorian. This brings into question an element of the scope of this project: current events. The goal is primarily to give historical context, eventually allowing some level of granular exploration of certain time periods of the Faith. It could however be helpful too in showing upcoming dates such as Holy Days. This will need to be decided in the future and for now only past events are generally going to be included.
 
 ## Contributing
+
 If you find this, you are welcome to submit issues, PRs, or contact the contributors with ideas. This may go nowhere, but it is started at this point.
 
-Licensing will need to be selected and published in this repository soon. Right now it is under a default restrictive assumed copyright license but the goal is to open it up for easy collaboration and additional projects. This should also make it more resilient so if it's forgotten about, someone else can continue on. 
+Licensing will need to be selected and published in this repository soon. Right now it is under a default restrictive assumed copyright license but the goal is to open it up for easy collaboration and additional projects. This should also make it more resilient so if it's forgotten about, someone else can continue on.
 
 ## Developing
 

--- a/src/lib/Timeline/Event.svelte
+++ b/src/lib/Timeline/Event.svelte
@@ -3,76 +3,27 @@
 	export let endDate: string;
 	export let label: string;
 
-	interface ToLocaleStringOptions {
-		localeMatcher?: 'best fit' | 'lookup';
-		style?: 'decimal' | 'currency' | 'percent' | 'unit';
-		currency?: string;
-		currencyDisplay?: 'symbol' | 'narrowSymbol' | 'code' | 'name';
-		useGrouping?: boolean;
-		minimumIntegerDigits?: number;
-		minimumFractionDigits?: number;
-		maximumFractionDigits?: number;
-		minimumSignificantDigits?: number;
-		maximumSignificantDigits?: number;
-		notation?: 'standard' | 'scientific' | 'engineering' | 'compact';
-		compactDisplay?: 'short' | 'long';
-		timeZone?: string;
-		hour12?: boolean;
-		hourCycle?: 'h11' | 'h12' | 'h23' | 'h24';
-		formatMatcher?: 'basic' | 'best fit';
-		weekday?: 'narrow' | 'short' | 'long';
-		era?: 'narrow' | 'short' | 'long';
-		year?: 'numeric' | '2-digit';
-		month?: 'numeric' | '2-digit' | 'narrow' | 'short' | 'long';
-		day?: 'numeric' | '2-digit';
-		hour?: 'numeric' | '2-digit';
-		minute?: 'numeric' | '2-digit';
-		second?: 'numeric' | '2-digit';
-		fractionalSecondDigits?: 2 | 1 | 3 | undefined;
-		weekdayFallback?: boolean;
-		numberingSystem?: string;
-		calendar?: string;
-		timeZoneName?: 'short' | 'long';
-	}
-
 	function extractYearFromDate(isoDateString: string): number {
-		// Create a Date object from the ISO date string
 		const date = new Date(isoDateString);
-
-		// Use the getUTCFullYear method to get the year
-		const year = date.getUTCFullYear();
-
-		return year;
-	}
-
-	function formatDateLocaleFriendly(isoDateString: string): string {
-		const options: ToLocaleStringOptions = {
-			year: 'numeric',
-			month: 'long',
-			day: 'numeric',
-			timeZone: 'UTC'
-		};
-		const date = new Date(isoDateString);
-		return date.toLocaleDateString(undefined, options);
+		return date.getUTCFullYear();
 	}
 </script>
 
 <div
-	style="--event-start-year:{extractYearFromDate(startDate)};
-    --event-end-year:{extractYearFromDate(endDate)};"
+	style="--event-start-year:{extractYearFromDate(startDate)}; --event-end-year:{extractYearFromDate(
+		endDate
+	)};"
 >
 	{label}
-	<!-- Event from {formatDateLocaleFriendly(startDate)} to {formatDateLocaleFriendly(endDate)}. -->
 </div>
 
 <style>
 	div {
-		grid-column-start: calc((var(--event-start-year) - var(--first-decade)) + 1);
-		grid-column-end: calc((var(--event-end-year) - var(--first-decade)) + 1);
+		grid-column-start: calc((var(--event-start-year) - var(--first-year)) + 1);
+		grid-column-end: calc((var(--event-end-year) - var(--first-year)) + 2);
 		background-color: var(--accent-bg);
 		padding: 0.2em 0.5em;
 		border-radius: 0.2em;
-		width: 100%;
 		z-index: 3;
 		opacity: 0.75;
 		text-align: center;

--- a/src/lib/Timeline/Navigator.svelte
+++ b/src/lib/Timeline/Navigator.svelte
@@ -1,221 +1,38 @@
 <script lang="ts">
-	import Event from '$lib/Timeline/Event.svelte';
-
-	let significantDates = [1844, 1853, 1892, 1921, 2016, 2021, 2044];
+	import EventComponent from '$lib/Timeline/Event.svelte';
+	import type { Event as EventData } from '$lib/types';
 
 	export let firstYear: number;
 	export let lastYear: number;
+	export let events: EventData[] = [];
 
 	function getDecades(firstYear: number, lastYear: number): number[] {
 		if (firstYear > lastYear) {
-			// Ensure start year is before or equal to end year.
 			return [];
 		}
-
 		const decades: number[] = [];
-		let currentDecade: number = Math.floor(firstYear / 10) * 10; // Find the first decade.
-
+		let currentDecade: number = Math.floor(firstYear / 10) * 10;
 		while (currentDecade <= Math.floor(lastYear / 10) * 10 + 10) {
 			decades.push(currentDecade);
-			currentDecade += 10; // Move to the next decade.
+			currentDecade += 10;
 		}
-
 		return decades;
 	}
 
 	let decadesArray: number[] = [];
-	$: {
-		decadesArray = getDecades(firstYear, lastYear);
-	}
-
-	let exampleEvents = [
-		{
-			startDate: '1844-01-01T08:00:00.000Z',
-			endDate: '2044-01-01T08:00:00.000Z',
-			label: 'Bahai Cycle'
-		},
-		{
-			startDate: '1844-01-01T08:00:00.000Z',
-			endDate: '2044-01-01T08:00:00.000Z',
-			label: 'Bahai Era'
-		},
-		{
-			startDate: '1853-01-01T08:00:00.000Z',
-			endDate: '2044-01-01T08:00:00.000Z',
-			label: 'Dispensation of Bahaullah'
-		},
-		{
-			startDate: '1844-01-01T08:00:00.000Z',
-			endDate: '1921-01-01T08:00:00.000Z',
-			label: 'Heroic Age'
-		},
-		{
-			startDate: '1921-01-01T08:00:00.000Z',
-			endDate: '2044-01-01T08:00:00.000Z',
-			label: 'Formative Age'
-		},
-		{
-			startDate: '1844-01-01T08:00:00.000Z',
-			endDate: '1853-01-01T08:00:00.000Z',
-			label: 'Ministry of the Báb'
-		},
-		{
-			startDate: '1853-01-01T08:00:00.000Z',
-			endDate: '1892-01-01T08:00:00.000Z',
-			label: 'Ministry of Bahaullah'
-		},
-		{
-			startDate: '1892-01-01T08:00:00.000Z',
-			endDate: '1921-01-01T08:00:00.000Z',
-			label: 'Ministry of Abdul-Baha'
-		},
-		{
-			startDate: '1921-01-01T08:00:00.000Z',
-			endDate: '1946-01-01T08:00:00.000Z',
-			label: '1st Epoch'
-		},
-		{
-			startDate: '1946-01-01T08:00:00.000Z',
-			endDate: '1963-01-01T08:00:00.000Z',
-			label: '2nd Epoch'
-		},
-		{
-			startDate: '1963-01-01T08:00:00.000Z',
-			endDate: '1986-01-01T08:00:00.000Z',
-			label: '3rd Epoch'
-		},
-		{
-			startDate: '1986-01-01T08:00:00.000Z',
-			endDate: '2023-01-01T08:00:00.000Z',
-			label: '5th Epoch'
-		},
-		{
-			startDate: '1937-01-01T08:00:00.000Z',
-			endDate: '2044-01-01T08:00:00.000Z',
-			label: 'Tablets of the Divine Plan'
-		},
-		{
-			startDate: '1937-01-01T08:00:00.000Z',
-			endDate: '1963-01-01T08:00:00.000Z',
-			label: '1st Epoch'
-		},
-		{
-			startDate: '1963-01-01T08:00:00.000Z',
-			endDate: '2021-01-01T08:00:00.000Z',
-			label: '2nd Epoch'
-		},
-		{
-			startDate: '2021-01-01T08:00:00.000Z',
-			endDate: '2044-01-01T08:00:00.000Z',
-			label: '3rd Epoch'
-		},
-		{
-			startDate: '1937-01-01T08:00:00.000Z',
-			endDate: '1946-01-01T08:00:00.000Z',
-			label: '7YP'
-		},
-		{
-			startDate: '1946-01-01T08:00:00.000Z',
-			endDate: '1953-01-01T08:00:00.000Z',
-			label: '7YP'
-		},
-		{
-			startDate: '1953-01-01T08:00:00.000Z',
-			endDate: '1963-01-01T08:00:00.000Z',
-			label: '10YC'
-		},
-		{
-			startDate: '1964-01-01T08:00:00.000Z',
-			endDate: '1973-01-01T08:00:00.000Z',
-			label: '9YP'
-		},
-		{
-			startDate: '1974-01-01T08:00:00.000Z',
-			endDate: '1979-01-01T08:00:00.000Z',
-			label: '5YP'
-		},
-		{
-			startDate: '1979-01-01T08:00:00.000Z',
-			endDate: '1986-01-01T08:00:00.000Z',
-			label: '7YP'
-		},
-		{
-			startDate: '1986-01-01T08:00:00.000Z',
-			endDate: '1992-01-01T08:00:00.000Z',
-			label: '6YP'
-		},
-		{
-			startDate: '1993-01-01T08:00:00.000Z',
-			endDate: '1996-01-01T08:00:00.000Z',
-			label: '3YP'
-		},
-		{
-			startDate: '1996-01-01T08:00:00.000Z',
-			endDate: '2000-01-01T08:00:00.000Z',
-			label: '4YP'
-		},
-		{
-			startDate: '2000-01-01T08:00:00.000Z',
-			endDate: '2001-01-01T08:00:00.000Z',
-			label: '12MP'
-		},
-		{
-			startDate: '2001-01-01T08:00:00.000Z',
-			endDate: '2006-01-01T08:00:00.000Z',
-			label: '5YP'
-		},
-		{
-			startDate: '2006-01-01T08:00:00.000Z',
-			endDate: '2011-01-01T08:00:00.000Z',
-			label: '5YP'
-		},
-		{
-			startDate: '2011-01-01T08:00:00.000Z',
-			endDate: '2016-01-01T08:00:00.000Z',
-			label: '5YP'
-		},
-		{
-			startDate: '2016-01-01T08:00:00.000Z',
-			endDate: '2021-01-01T08:00:00.000Z',
-			label: '5YP'
-		},
-		{
-			startDate: '2021-01-01T08:00:00.000Z',
-			endDate: '2022-01-01T08:00:00.000Z',
-			label: '1YP'
-		},
-		{
-			startDate: '2022-01-01T08:00:00.000Z',
-			endDate: '2031-01-01T08:00:00.000Z',
-			label: '9YP'
-		}
-	];
+	$: decadesArray = getDecades(firstYear, lastYear);
 </script>
 
-<!-- @component
-Provides a navigation bar at the bottom of the page with the timeline.
- -->
-<main
-	style="--first-year:{firstYear};
-	--last-year:{lastYear};
-	--first-decade:{decadesArray[0]};
-	--last-decade:{decadesArray[-1]};
-	--number-of-decades:{decadesArray.length};"
->
-	<!-- TODO: These events will of course need to be derived from the headless CMS, and will need to be restructured at that point -->
-	{#each exampleEvents as { startDate, endDate, label }}
-		<Event {startDate} {endDate} {label} />
+<main style="--first-year:{firstYear}; --last-year:{lastYear};">
+	{#each events as { startDate, endDate, label }}
+		<EventComponent {startDate} {endDate} {label} />
 	{/each}
 	<nav>
-		<!-- Listing all the decades -->
-		<!-- TODO: When zoomed in to only a couple decades, label all individual years -->
 		{#each decadesArray as year}
 			<time
 				datetime={new Date('1 January ' + year).toISOString()}
-				style="--decade-year:{year};--content:'{year}';"
+				style="--decade-year:{year};--content:'{year}';">&nbsp;</time
 			>
-				&nbsp;
-			</time>
 		{/each}
 	</nav>
 </main>
@@ -223,55 +40,41 @@ Provides a navigation bar at the bottom of the page with the timeline.
 <style>
 	main {
 		--spacing: 2.5em;
-		--inner-height: calc(100vh - var(--spacing) * 2);
-		--inner-width: calc(100vw - var(--spacing) * 2);
-		--number-of-years: calc(var(--last-decade) - var(--first-decade));
-		/* Create one column for each year */
-		--timeline-grid: repeat(
-			var(--number-of-years),
-			calc(var(--inner-width) / var(--number-of-years))
-		);
-		grid-template-columns: var(--timeline-grid);
-		grid-template-rows: auto;
-		row-gap: calc(var(--spacing) / 4);
+		--year-width: 6rem;
+		--number-of-years: calc(var(--last-year) - var(--first-year) + 1);
 		display: grid;
-		align-content: baseline;
-		position: relative;
-		width: 100vw;
+		grid-template-columns: repeat(var(--number-of-years), var(--year-width));
+		grid-auto-rows: min-content;
+		row-gap: calc(var(--spacing) / 4);
+		align-content: start;
+		width: max(100vw, calc(var(--number-of-years) * var(--year-width)));
 		height: 100vh;
 		background-color: var(--bg);
 		padding: var(--spacing);
-		z-index: 1;
-		overflow: hidden;
+		overflow: auto;
 	}
+
 	nav {
-		position: absolute;
+		grid-row: -1;
+		grid-column: 1 / -1;
 		display: grid;
-		/* TODO: In the future when `subgrid` is supported, this can be refactored to avoid multiple grids */
-		grid-template-columns: var(--timeline-grid);
-		grid-template-rows: 1fr;
-		/* width: calc(100vw - var(--spacing) * 2); */
-		width: 100vw;
+		grid-template-columns: repeat(var(--number-of-years), var(--year-width));
 		height: var(--spacing);
-		left: 0;
-		right: 0;
-		bottom: 0;
-		margin: var(--spacing) 0;
-		/* padding: 0 calc(var(--spacing) / 2); */
+		margin-top: var(--spacing);
 	}
+
 	time {
 		position: relative;
 		width: max-content;
-		height: 1em;
 		text-align: left;
 		align-self: center;
 		justify-self: center;
 		color: var(--text-light);
-		--year-offset: calc(var(--decade-year) - var(--first-decade) + 1);
+		--year-offset: calc(var(--decade-year) - var(--first-year) + 1);
 		grid-column-start: var(--year-offset);
 		grid-column-end: calc(var(--year-offset) + 10);
-		grid-row: 1 / 1;
 	}
+
 	time::before {
 		content: var(--content);
 		--padding: 0.35em;
@@ -285,18 +88,24 @@ Provides a navigation bar at the bottom of the page with the timeline.
 		box-sizing: unset;
 		z-index: 3;
 	}
+
 	time::after {
 		content: '';
 		position: absolute;
-		/* top: -100vh; */
 		left: 0;
 		right: 0;
-		bottom: calc(-1 * var(--spacing) * 1.5);
-		height: 100vh;
+		top: calc(-1 * (100vh - var(--spacing)));
+		height: calc(100vh - var(--spacing));
 		width: 1px;
-		z-index: 1; /* Place it behind other content */
-		border-left: 1px solid var(--accent); /* Thin line */
+		z-index: 1;
+		border-left: 1px solid var(--accent);
 		opacity: 0.15;
-		pointer-events: none; /* Allow clicks to go through it */
+		pointer-events: none;
+	}
+
+	@media (max-width: 600px) {
+		main {
+			--year-width: 4rem;
+		}
 	}
 </style>

--- a/src/lib/styles/simple.css
+++ b/src/lib/styles/simple.css
@@ -22,22 +22,22 @@
 
 /* Dark theme */
 @media (prefers-color-scheme: dark) {
-  :root,
-  ::backdrop {
-    color-scheme: dark;
-    --bg: #212121;
-    --accent-bg: #2b2b2b;
-    --text: #dcdcdc;
-    --text-light: #ababab;
-    --accent: #ffb300;
-    --code: #f06292;
-    --preformatted: #ccc;
-    --disabled: #111;
-  }
-  img,
-  video {
-    opacity: 0.8;
-  }
+	:root,
+	::backdrop {
+		color-scheme: dark;
+		--bg: #212121;
+		--accent-bg: #2b2b2b;
+		--text: #dcdcdc;
+		--text-light: #ababab;
+		--accent: #ffb300;
+		--code: #f06292;
+		--preformatted: #ccc;
+		--disabled: #111;
+	}
+	img,
+	video {
+		opacity: 0.8;
+	}
 }
 
 /* Reset box-sizing */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,5 @@
+export interface Event {
+	startDate: string;
+	endDate: string;
+	label: string;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,7 @@
-<script>
+<script lang="ts">
 	import Navigator from '$lib/Timeline/Navigator.svelte';
+	import type { Event } from '$lib/types';
+	export let data: { events: Event[] };
 </script>
 
-<Navigator firstYear={1715} lastYear={1900} />
+<Navigator firstYear={1715} lastYear={1900} events={data.events} />

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,0 +1,11 @@
+import type { PageLoad } from './$types';
+import type { Event } from '$lib/types';
+
+export const load: PageLoad = async ({ fetch }) => {
+	const res = await fetch('/data/events.json');
+	if (!res.ok) {
+		throw new Error('Failed to fetch events');
+	}
+	const events: Event[] = await res.json();
+	return { events };
+};

--- a/static/data/events.json
+++ b/static/data/events.json
@@ -1,0 +1,158 @@
+[
+	{
+		"startDate": "1844-01-01T08:00:00.000Z",
+		"endDate": "2044-01-01T08:00:00.000Z",
+		"label": "Bahai Cycle"
+	},
+	{
+		"startDate": "1844-01-01T08:00:00.000Z",
+		"endDate": "2044-01-01T08:00:00.000Z",
+		"label": "Bahai Era"
+	},
+	{
+		"startDate": "1853-01-01T08:00:00.000Z",
+		"endDate": "2044-01-01T08:00:00.000Z",
+		"label": "Dispensation of Bahaullah"
+	},
+	{
+		"startDate": "1844-01-01T08:00:00.000Z",
+		"endDate": "1921-01-01T08:00:00.000Z",
+		"label": "Heroic Age"
+	},
+	{
+		"startDate": "1921-01-01T08:00:00.000Z",
+		"endDate": "2044-01-01T08:00:00.000Z",
+		"label": "Formative Age"
+	},
+	{
+		"startDate": "1844-01-01T08:00:00.000Z",
+		"endDate": "1853-01-01T08:00:00.000Z",
+		"label": "Ministry of the Báb"
+	},
+	{
+		"startDate": "1853-01-01T08:00:00.000Z",
+		"endDate": "1892-01-01T08:00:00.000Z",
+		"label": "Ministry of Bahaullah"
+	},
+	{
+		"startDate": "1892-01-01T08:00:00.000Z",
+		"endDate": "1921-01-01T08:00:00.000Z",
+		"label": "Ministry of Abdul-Baha"
+	},
+	{
+		"startDate": "1921-01-01T08:00:00.000Z",
+		"endDate": "1946-01-01T08:00:00.000Z",
+		"label": "1st Epoch"
+	},
+	{
+		"startDate": "1946-01-01T08:00:00.000Z",
+		"endDate": "1963-01-01T08:00:00.000Z",
+		"label": "2nd Epoch"
+	},
+	{
+		"startDate": "1963-01-01T08:00:00.000Z",
+		"endDate": "1986-01-01T08:00:00.000Z",
+		"label": "3rd Epoch"
+	},
+	{
+		"startDate": "1986-01-01T08:00:00.000Z",
+		"endDate": "2023-01-01T08:00:00.000Z",
+		"label": "5th Epoch"
+	},
+	{
+		"startDate": "1937-01-01T08:00:00.000Z",
+		"endDate": "2044-01-01T08:00:00.000Z",
+		"label": "Tablets of the Divine Plan"
+	},
+	{
+		"startDate": "1937-01-01T08:00:00.000Z",
+		"endDate": "1963-01-01T08:00:00.000Z",
+		"label": "1st Epoch"
+	},
+	{
+		"startDate": "1963-01-01T08:00:00.000Z",
+		"endDate": "2021-01-01T08:00:00.000Z",
+		"label": "2nd Epoch"
+	},
+	{
+		"startDate": "2021-01-01T08:00:00.000Z",
+		"endDate": "2044-01-01T08:00:00.000Z",
+		"label": "3rd Epoch"
+	},
+	{
+		"startDate": "1937-01-01T08:00:00.000Z",
+		"endDate": "1946-01-01T08:00:00.000Z",
+		"label": "7YP"
+	},
+	{
+		"startDate": "1946-01-01T08:00:00.000Z",
+		"endDate": "1953-01-01T08:00:00.000Z",
+		"label": "7YP"
+	},
+	{
+		"startDate": "1953-01-01T08:00:00.000Z",
+		"endDate": "1963-01-01T08:00:00.000Z",
+		"label": "10YC"
+	},
+	{
+		"startDate": "1964-01-01T08:00:00.000Z",
+		"endDate": "1973-01-01T08:00:00.000Z",
+		"label": "9YP"
+	},
+	{
+		"startDate": "1974-01-01T08:00:00.000Z",
+		"endDate": "1979-01-01T08:00:00.000Z",
+		"label": "5YP"
+	},
+	{
+		"startDate": "1979-01-01T08:00:00.000Z",
+		"endDate": "1986-01-01T08:00:00.000Z",
+		"label": "7YP"
+	},
+	{
+		"startDate": "1986-01-01T08:00:00.000Z",
+		"endDate": "1992-01-01T08:00:00.000Z",
+		"label": "6YP"
+	},
+	{
+		"startDate": "1993-01-01T08:00:00.000Z",
+		"endDate": "1996-01-01T08:00:00.000Z",
+		"label": "3YP"
+	},
+	{
+		"startDate": "1996-01-01T08:00:00.000Z",
+		"endDate": "2000-01-01T08:00:00.000Z",
+		"label": "4YP"
+	},
+	{
+		"startDate": "2000-01-01T08:00:00.000Z",
+		"endDate": "2001-01-01T08:00:00.000Z",
+		"label": "12MP"
+	},
+	{
+		"startDate": "2001-01-01T08:00:00.000Z",
+		"endDate": "2006-01-01T08:00:00.000Z",
+		"label": "5YP"
+	},
+	{
+		"startDate": "2006-01-01T08:00:00.000Z",
+		"endDate": "2011-01-01T08:00:00.000Z",
+		"label": "5YP"
+	},
+	{
+		"startDate": "2011-01-01T08:00:00.000Z",
+		"endDate": "2016-01-01T08:00:00.000Z",
+		"label": "5YP"
+	},
+	{
+		"startDate": "2016-01-01T08:00:00.000Z",
+		"endDate": "2021-01-01T08:00:00.000Z",
+		"label": "5YP"
+	},
+	{
+		"startDate": "2021-01-01T08:00:00.000Z",
+		"endDate": "2022-01-01T08:00:00.000Z",
+		"label": "1YP"
+	},
+	{ "startDate": "2022-01-01T08:00:00.000Z", "endDate": "2031-01-01T08:00:00.000Z", "label": "9YP" }
+]


### PR DESCRIPTION
## Summary
- load timeline events from JSON via page load
- accept events as Navigator prop and make timeline scrollable
- add responsive year width and mobile breakpoint
- restructure timeline grid to rely on CSS Grid and integrate decade navigation
- fix event spans to include the end year

## Testing
- `npm run lint`
- `npx vitest run`
- `npx playwright test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1080/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_b_68ae43d70ac883228caff4766cff3714